### PR TITLE
DBに取得済みツイートの保持と最新ツイート取得間隔の制御

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,5 +62,6 @@ dependencies {
     compile 'com.github.gfx.android.orma:orma:2.4.7'
     compile 'com.facebook.stetho:stetho:1.3.1'
     compile 'com.facebook.stetho:stetho-okhttp:1.3.1'
+    compile 'org.threeten:threetenbp:1.3.1'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,9 +52,11 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.0.1'
     compile 'com.google.android.gms:play-services-appindexing:8.1.0'
     compile 'org.twitter4j:twitter4j-core:4.0.4'
-    compile 'com.google.dagger:dagger:2.2'
-    apt 'com.google.dagger:dagger-compiler:2.2'
+    apt 'com.google.guava:guava:19.0'
+    compile 'com.google.dagger:dagger:2.4'
+    apt 'com.google.dagger:dagger-compiler:2.4'
     provided 'javax.annotation:jsr250-api:1.0'
     compile 'com.github.bumptech.glide:glide:3.6.1'
-
+    apt 'com.github.gfx.android.orma:orma-processor:2.4.7'
+    compile 'com.github.gfx.android.orma:orma:2.4.7'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,11 @@ dependencies {
     compile 'com.google.dagger:dagger:2.4'
     apt 'com.google.dagger:dagger-compiler:2.4'
     provided 'javax.annotation:jsr250-api:1.0'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
+    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.github.bumptech.glide:okhttp-integration:1.4.0'
     apt 'com.github.gfx.android.orma:orma-processor:2.4.7'
     compile 'com.github.gfx.android.orma:orma:2.4.7'
+    compile 'com.facebook.stetho:stetho:1.3.1'
+    compile 'com.facebook.stetho:stetho-okhttp:1.3.1'
+
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keep class com.facebook.stetho.** {*;}

--- a/app/src/main/java/application/android/marshi/papercrane/TwitterClient.java
+++ b/app/src/main/java/application/android/marshi/papercrane/TwitterClient.java
@@ -12,6 +12,8 @@ public class TwitterClient {
 
 	private static Twitter twitter;
 
+	private static boolean isVerified = false;
+
 	static {
 		twitter  = TwitterFactory.getSingleton();
 		twitter.setOAuthConsumer(BuildConfig.CONSUMER_KEY, BuildConfig.SECRET_KEY);
@@ -20,8 +22,12 @@ public class TwitterClient {
 	private TwitterClient() { }
 
 	public static Twitter getInstance(AccessToken accessToken) throws TwitterException {
+		if (isVerified) {
+			return twitter;
+		}
 		twitter.setOAuthAccessToken(accessToken);
 		twitter.verifyCredentials();
+		isVerified = true;
 		return twitter;
 	}
 

--- a/app/src/main/java/application/android/marshi/papercrane/database/Cache.java
+++ b/app/src/main/java/application/android/marshi/papercrane/database/Cache.java
@@ -1,0 +1,38 @@
+package application.android.marshi.papercrane.database;
+
+import application.android.marshi.papercrane.database.dto.Tweet;
+import application.android.marshi.papercrane.enums.TweetPage;
+import application.android.marshi.papercrane.repository.TweetStoreRepository;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author marshi on 2016/05/29.
+ */
+public class Cache {
+
+	private long cacheSize = 1000;
+
+	@Inject
+	public Cache() {}
+
+	@Inject
+	TweetStoreRepository tweetStoreRepository;
+
+	public void set(List<Tweet> tweetList, TweetPage tweetPage) {
+		tweetStoreRepository.insertTweetList(tweetList);
+		List<Tweet> tweets = tweetStoreRepository.selectOrderYByDate(tweetPage, cacheSize);
+		List<Long> ids = new ArrayList<>();
+		for (Tweet t : tweets) {
+			ids.add(t.getId());
+		}
+		tweetStoreRepository.deleteTweetList(ids);
+	}
+
+	public List<Tweet> get(TweetPage tweetPage) {
+		return tweetStoreRepository.selectOrderYByDate(tweetPage);
+	}
+
+}

--- a/app/src/main/java/application/android/marshi/papercrane/database/dto/Tweet.java
+++ b/app/src/main/java/application/android/marshi/papercrane/database/dto/Tweet.java
@@ -1,0 +1,56 @@
+package application.android.marshi.papercrane.database.dto;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.PrimaryKey;
+import com.github.gfx.android.orma.annotation.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * @author marshi on 2016/05/29.
+ */
+@Table
+@NoArgsConstructor
+@Getter
+public class Tweet {
+
+    public Tweet(Long tweetId, String userId, String userName, String content, String profileImageUrl, Date tweetAt, String tweetPage) {
+        this.tweetId = tweetId;
+        this.userId = userId;
+        this.userName = userName;
+        this.content = content;
+        this.profileImageUrl = profileImageUrl;
+        this.tweetAt = tweetAt;
+        this.tweetPage = tweetPage;
+    }
+
+    @PrimaryKey(autoincrement = true, auto = true)
+	public long id;
+
+    @Column
+    public Long tweetId;
+
+    @Column
+    public String userId;
+
+    @Column
+    public String userName;
+
+    @Column
+    public String content;
+
+    @Column
+    public String profileImageUrl;
+
+    @Column(indexed = true)
+    public Date tweetAt;
+
+	/**
+	 * ページを表す文字列.
+     */
+    @Column(indexed = true)
+    public String tweetPage;
+
+}

--- a/app/src/main/java/application/android/marshi/papercrane/di/App.java
+++ b/app/src/main/java/application/android/marshi/papercrane/di/App.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import application.android.marshi.papercrane.di.component.AppComponent;
 import application.android.marshi.papercrane.di.component.DaggerAppComponent;
 import application.android.marshi.papercrane.di.module.AppModule;
+import com.facebook.stetho.Stetho;
 
 /**
  * @author marshi on 2016/04/17.
@@ -16,12 +17,22 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         initializeInjector();
+        initializeStetho();
     }
 
     private void initializeInjector() {
         appComponent = DaggerAppComponent.builder()
                 .appModule(new AppModule(this))
                 .build();
+    }
+
+    private void initializeStetho() {
+        Stetho.initialize(
+            Stetho.newInitializerBuilder(this)
+                .enableDumpapp(Stetho.defaultDumperPluginsProvider(this))
+                .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(this))
+                .build()
+        );
     }
 
     public static AppComponent getApplicationComponent() {

--- a/app/src/main/java/application/android/marshi/papercrane/di/component/AppComponent.java
+++ b/app/src/main/java/application/android/marshi/papercrane/di/component/AppComponent.java
@@ -4,6 +4,7 @@ import application.android.marshi.papercrane.activity.TimelineActivity;
 import application.android.marshi.papercrane.activity.LoginActivity;
 import application.android.marshi.papercrane.activity.MainActivity;
 import application.android.marshi.papercrane.di.module.AppModule;
+import application.android.marshi.papercrane.di.module.DatabaseModule;
 import application.android.marshi.papercrane.di.module.RepositoryModule;
 import application.android.marshi.papercrane.fragment.TweetListFragment;
 import dagger.Component;
@@ -14,7 +15,7 @@ import javax.inject.Singleton;
  * @author marshi on 2016/04/17.
  */
 @Singleton
-@Component(modules = {RepositoryModule.class, AppModule.class})
+@Component(modules = {RepositoryModule.class, AppModule.class, DatabaseModule.class})
 public interface AppComponent {
 
 	void inject(MainActivity mainActivity);
@@ -24,4 +25,5 @@ public interface AppComponent {
 	void inject(TimelineActivity timelineActivity);
 
 	void inject(TweetListFragment tweetListFragment);
+
 }

--- a/app/src/main/java/application/android/marshi/papercrane/di/module/DatabaseModule.java
+++ b/app/src/main/java/application/android/marshi/papercrane/di/module/DatabaseModule.java
@@ -1,0 +1,22 @@
+package application.android.marshi.papercrane.di.module;
+
+import android.content.Context;
+import application.android.marshi.papercrane.database.dto.OrmaDatabase;
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Singleton;
+
+/**
+ * @author marshi on 2016/05/29.
+ */
+@Module
+public class DatabaseModule {
+
+	@Singleton
+	@Provides
+	public OrmaDatabase provideOrmaDatabase(Context context) {
+		return OrmaDatabase.builder(context).build();
+	}
+
+}

--- a/app/src/main/java/application/android/marshi/papercrane/di/module/RepositoryModule.java
+++ b/app/src/main/java/application/android/marshi/papercrane/di/module/RepositoryModule.java
@@ -2,6 +2,7 @@ package application.android.marshi.papercrane.di.module;
 
 import android.content.Context;
 import application.android.marshi.papercrane.repository.AccessTokenRepository;
+import application.android.marshi.papercrane.repository.LastTweetAccessTimeRepository;
 import dagger.Module;
 import dagger.Provides;
 
@@ -18,6 +19,12 @@ public class RepositoryModule {
 	@Provides
 	public AccessTokenRepository provideAccessTokenRepository(Context context) {
 		return new AccessTokenRepository(context);
+	}
+
+	@Singleton
+	@Provides
+	public LastTweetAccessTimeRepository lastTweetAccessTimeRepository() {
+		return new LastTweetAccessTimeRepository();
 	}
 
 }

--- a/app/src/main/java/application/android/marshi/papercrane/domain/usecase/UseCase.java
+++ b/app/src/main/java/application/android/marshi/papercrane/domain/usecase/UseCase.java
@@ -17,11 +17,11 @@ abstract public class UseCase<P, R> {
 			R result = null;
 			try {
 				result = call(param);
+				subscriber.onNext(result);
+				subscriber.onCompleted();
 			} catch (TwitterException e) {
 				subscriber.onError(e);
 			}
-			subscriber.onNext(result);
-			subscriber.onCompleted();
 		});
 	}
 }

--- a/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetStoredTimelineUseCase.java
+++ b/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetStoredTimelineUseCase.java
@@ -1,0 +1,44 @@
+package application.android.marshi.papercrane.domain.usecase.timeline;
+
+import application.android.marshi.papercrane.database.dto.Tweet;
+import application.android.marshi.papercrane.domain.model.TweetItem;
+import application.android.marshi.papercrane.domain.usecase.UseCase;
+import application.android.marshi.papercrane.enums.TweetPage;
+import application.android.marshi.papercrane.repository.TweetStoreRepository;
+import twitter4j.TwitterException;
+
+import javax.inject.Inject;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author marshi on 2016/05/29.
+ */
+public class GetStoredTimelineUseCase extends UseCase<TweetPage, List<TweetItem>> {
+
+	@Inject
+	public GetStoredTimelineUseCase() {}
+
+	@Inject
+	TweetStoreRepository tweetStoreRepository;
+
+	@Override
+	protected List<TweetItem> call(TweetPage tweetPage) throws TwitterException {
+		List<Tweet> tweets = tweetStoreRepository.selectOrderYByDate(tweetPage);
+		AbstractList<TweetItem> tweetItemList = new ArrayList<>();
+		for (Tweet tweet : tweets) {
+			tweetItemList.add(
+				new TweetItem(
+					tweet.getTweetId(),
+					tweet.getUserId(),
+					tweet.getContent(),
+					tweet.getUserName(),
+					tweet.getProfileImageUrl(),
+					tweet.getTweetAt()
+				)
+			);
+		}
+		return tweetItemList;
+	}
+}

--- a/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetStoredTimelineUseCase.java
+++ b/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetStoredTimelineUseCase.java
@@ -1,10 +1,10 @@
 package application.android.marshi.papercrane.domain.usecase.timeline;
 
+import application.android.marshi.papercrane.database.Cache;
 import application.android.marshi.papercrane.database.dto.Tweet;
 import application.android.marshi.papercrane.domain.model.TweetItem;
 import application.android.marshi.papercrane.domain.usecase.UseCase;
 import application.android.marshi.papercrane.enums.TweetPage;
-import application.android.marshi.papercrane.repository.TweetStoreRepository;
 import twitter4j.TwitterException;
 
 import javax.inject.Inject;
@@ -21,11 +21,11 @@ public class GetStoredTimelineUseCase extends UseCase<TweetPage, List<TweetItem>
 	public GetStoredTimelineUseCase() {}
 
 	@Inject
-	TweetStoreRepository tweetStoreRepository;
+	Cache cache;
 
 	@Override
 	protected List<TweetItem> call(TweetPage tweetPage) throws TwitterException {
-		List<Tweet> tweets = tweetStoreRepository.selectOrderYByDate(tweetPage);
+		List<Tweet> tweets = cache.get(tweetPage);
 		AbstractList<TweetItem> tweetItemList = new ArrayList<>();
 		for (Tweet tweet : tweets) {
 			tweetItemList.add(

--- a/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetTimelineUseCase.java
+++ b/app/src/main/java/application/android/marshi/papercrane/domain/usecase/timeline/GetTimelineUseCase.java
@@ -25,9 +25,7 @@ public class GetTimelineUseCase extends UseCase<GetTimelineUseCase.TimelineReque
 	TweetRepository tweetRepository;
 
 	protected List<TweetItem> call(TimelineRequest request) throws TwitterException {
-		List<TweetItem> tweetItemList;
-		tweetItemList = tweetRepository.getTweetItemList(request.getAccessToken(), request.getPaging(), request.getType());
-		return tweetItemList;
+		return tweetRepository.getTweetItemList(request.getAccessToken(), request.getPaging(), request.getType());
 	}
 
 	@Getter

--- a/app/src/main/java/application/android/marshi/papercrane/fragment/TweetListFragment.java
+++ b/app/src/main/java/application/android/marshi/papercrane/fragment/TweetListFragment.java
@@ -104,11 +104,9 @@ public class TweetListFragment extends RxFragment {
 	@Override
 	public void onResume() {
 		super.onResume();
-		AccessToken accessToken = accessTokenService.getAccessToken();
 		if (tweetRecyclerViewAdapter.mValues.isEmpty()) {
-			timelineService.loadTweetItems(
+			timelineService.loadStoredTweets(
 				this,
-				accessToken,
 				tweetPage,
 				tweetItemList -> tweetRecyclerViewAdapter.addLast(tweetItemList)
 			);

--- a/app/src/main/java/application/android/marshi/papercrane/repository/LastTweetAccessTimeRepository.java
+++ b/app/src/main/java/application/android/marshi/papercrane/repository/LastTweetAccessTimeRepository.java
@@ -1,0 +1,25 @@
+package application.android.marshi.papercrane.repository;
+
+import org.threeten.bp.LocalDateTime;
+
+import javax.inject.Inject;
+
+/**
+ * @author marshi on 2016/05/30.
+ */
+public class LastTweetAccessTimeRepository {
+
+	private LocalDateTime localDateTime;
+
+	@Inject
+	public LastTweetAccessTimeRepository() {}
+
+	public void set() {
+		localDateTime = LocalDateTime.now();
+	}
+
+	public LocalDateTime get() {
+		return localDateTime;
+	}
+
+}

--- a/app/src/main/java/application/android/marshi/papercrane/repository/TweetRepository.java
+++ b/app/src/main/java/application/android/marshi/papercrane/repository/TweetRepository.java
@@ -26,9 +26,13 @@ public class TweetRepository {
 	@Inject
 	public TweetRepository(){}
 
+	@Inject
+	LastTweetAccessTimeRepository lastTweetAccessTimeRepository;
+
 	public List<TweetItem> getTweetItemList(AccessToken accessToken, Paging paging, TweetPage tweetPage) throws TwitterException {
+		lastTweetAccessTimeRepository.set();
 		Twitter twitter = TwitterClient.getInstance(accessToken);
-		ResponseList<Status> statuses =  twitter.getHomeTimeline(paging);
+		ResponseList<Status> statuses;
 		switch (tweetPage) {
 			case MentionTimeline:
 				statuses =  twitter.getMentionsTimeline(paging);

--- a/app/src/main/java/application/android/marshi/papercrane/repository/TweetStoreRepository.java
+++ b/app/src/main/java/application/android/marshi/papercrane/repository/TweetStoreRepository.java
@@ -34,6 +34,17 @@ public class TweetStoreRepository {
 		}
 	}
 
+	public List<Tweet> selectOrderYByDate(TweetPage tweetPage, long offset) {
+		return ormaDatabase
+			.relationOfTweet()
+			.selector()
+			.tweetPageEq(tweetPage.name())
+			.orderByTweetAtDesc()
+			.offset(offset)
+			.limit(1000)
+			.toList();
+	}
+
 	public List<Tweet> selectOrderYByDate(TweetPage tweetPage) {
 		return ormaDatabase
 			.relationOfTweet()

--- a/app/src/main/java/application/android/marshi/papercrane/repository/TweetStoreRepository.java
+++ b/app/src/main/java/application/android/marshi/papercrane/repository/TweetStoreRepository.java
@@ -1,0 +1,46 @@
+package application.android.marshi.papercrane.repository;
+
+import android.util.Log;
+import application.android.marshi.papercrane.database.dto.OrmaDatabase;
+import application.android.marshi.papercrane.database.dto.Tweet;
+import application.android.marshi.papercrane.enums.TweetPage;
+import com.github.gfx.android.orma.exception.OrmaException;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * @author marshi on 2016/05/29.
+ */
+public class TweetStoreRepository {
+
+	@Inject
+	public TweetStoreRepository(){}
+
+	@Inject
+	public OrmaDatabase ormaDatabase;
+
+	public void insertTweetList(List<Tweet> tweetList) {
+		try {
+			ormaDatabase.relationOfTweet().inserter().executeAll(tweetList);
+		} catch (OrmaException e) {
+			Log.e("orma", "", e);
+		}
+	}
+
+	public void deleteTweetList(List<Long> tweetIdList) {
+		for (Long tweetId : tweetIdList) {
+			ormaDatabase.relationOfTweet().deleter().idEq(tweetId).execute();
+		}
+	}
+
+	public List<Tweet> selectOrderYByDate(TweetPage tweetPage) {
+		return ormaDatabase
+			.relationOfTweet()
+			.selector()
+			.tweetPageEq(tweetPage.name())
+			.orderByTweetAtDesc()
+			.toList();
+	}
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
**DBに取得済みツイートの保持**
最新ツイートX件をDBに保持
ツイートを取得するたびにこれを更新する

**最新ツイート取得間隔の制御**
APIの上限を超えると15分待たないといけなくなるので、最新ツイートの取得は1分間隔をあけなければできないように制御
